### PR TITLE
Refactor drivetrain motor speed control and improve docstring formatting

### DIFF
--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -1,5 +1,6 @@
 import constants as constant
-from gpiozero import PWMOutputDevice, DigitalOutputDevice # type: ignore
+from gpiozero import PWMOutputDevice, DigitalOutputDevice  # type: ignore
+
 
 class Drivetrain:
     """
@@ -13,7 +14,8 @@ class Drivetrain:
     Methods
     -------
     __init__()
-        Initializes the Drivetrain with motor controllers for the left and right motors.
+        Initializes the Drivetrain with motor controllers for the left and
+        right motors.
     """
     def __init__(self):
         self.left_motor = PWMOutputDevice(constant.LEFT_MOTOR_PIN)
@@ -28,35 +30,42 @@ class Drivetrain:
         """
         Sets the speed of the left and right motors of the drivetrain.
         Parameters:
-        left_speed (float): The speed to set for the left motor. Positive values move the motor forward, negative values move it backward, and zero stops the motor.
-        right_speed (float): The speed to set for the right motor. Positive values move the motor forward, negative values move it backward, and zero stops the motor.
-        The method also controls the state of the motor direction pins (in_1, in_2 for the left motor and in_3, in_4 for the right motor) based on the speed values.
+        left_speed (float): The speed to set for the left motor. Positive
+        values move the motor forward, negative values move it backward, and
+        zero stops the motor.
+        right_speed (float): The speed to set for the right motor. Positive
+        values move the motor forward, negative values move it backward, and
+        values move the motor forward, negative values move it backward, and
+        zero stops the motor.
+        The method also controls the state of the motor direction pins (in_1,
+        in_2 for the left motor and in_3, in_4 for the right motor) based on
+        the speed values.
         """
-    
+
         # Set the speed of the left motor
         if left_speed > 0:
-            self.left_motor.set(left_speed)
+            self.left_motor.value = left_speed
             self.in_1.on()
             self.in_2.off()
         elif left_speed < 0:
-            self.left_motor.set(-left_speed)
+            self.left_motor.value = -left_speed
             self.in_1.off()
             self.in_2.on()
         elif left_speed == 0:
-            self.left_motor.set(left_speed)
+            self.left_motor.value = left_speed
             self.in_1.off()
             self.in_2.off()
 
         # Set the speed of the right motor
         if right_speed > 0:
-            self.right_motor.set(right_speed)
+            self.right_motor.value = right_speed
             self.in_3.on()
             self.in_4.off()
         elif right_speed < 0:
-            self.right_motor.set(-right_speed)
+            self.right_motor.value = -right_speed
             self.in_3.off()
             self.in_4.on()
         elif right_speed == 0:
-            self.right_motor.set(right_speed)
+            self.right_motor.value = right_speed
             self.in_3.off()
             self.in_4.off()


### PR DESCRIPTION
This pull request makes improvements to the `Drivetrain` subsystem code, focusing on clarifying docstrings and updating how motor speeds are set. The most significant change is the replacement of the deprecated `.set()` method with direct assignment to the `.value` property for motor speed control, which aligns with best practices for the `PWMOutputDevice` class.

Motor speed control update:
* Replaced usage of `self.left_motor.set()` and `self.right_motor.set()` with direct assignment to `self.left_motor.value` and `self.right_motor.value` in the `set_drive_speed` method for more idiomatic and reliable motor speed control.

Documentation improvements:
* Reformatted and clarified docstrings in the `Drivetrain` class and its methods to improve readability and maintain consistency with Python documentation standards. [[1]](diffhunk://#diff-b894b11d3185800269a474a10e193cac3662809abe81a12fee0aa9255308b891L16-R18) [[2]](diffhunk://#diff-b894b11d3185800269a474a10e193cac3662809abe81a12fee0aa9255308b891L31-R69)

Other minor changes:
* Added a blank line after imports for improved code style in `subsystems/drivetrain.py`.